### PR TITLE
Adaptor installer

### DIFF
--- a/bin/da_installer
+++ b/bin/da_installer
@@ -30,11 +30,50 @@ main() {
 }
 
 da_install() {
+	DA_DIR=$1
+	[ -d "$DA_DIR" ] || \
+		fatal "device-adaptor dir not found: $DA_DIR"
+
+	read_properties_files
+	check_sms_router_conf
 	:;
 }
 
 da_uninstall() {
 	:;
+}
+
+
+read_properties_files() {
+	device_properties="conf/device.properties"
+	[ -f "$DA_DIR/$device_properties" ] || \
+		fatal "file not found: $device_properties"
+
+	MAN_ID=$(read_property "$device_properties" "manufacturer.id")
+	MOD_ID=$(read_property "$device_properties" "model.id")
+	MOD_NAME=$(read_property "$device_properties" "model.name")
+	MAN_NAME=$(read_property "$device_properties" "manufacturer.name")
+}
+
+check_sms_router_conf() {
+	sms_router_conf="conf/sms_router.conf"
+	[ -f "$DA_DIR/$sms_router_conf" ] || \
+		fatal "file not found: $sms_router_conf"
+
+	spec=$(cat $DA_DIR/$sms_router_conf | egrep '^model' | awk '{print $2}')
+	man_id=$(cut -d : -f 1 <<< "$spec")
+	mod_id=$(cut -d : -f 2 <<< "$spec")
+
+	[ "$man_id" = "$MAN_ID" ] || \
+		fatal "inconsistent definition: man_id=$man_id MAN_ID=$MAN_ID"
+	[ "$mod_id" = "$MOD_ID" ] || \
+		fatal "inconsistent definition: mod_id=$mod_id MOD_ID=$MOD_ID"
+}
+
+read_property() {
+	file=$1
+	prop=$2
+	cat $DA_DIR/$file | egrep "^$prop" | cut -d = -f 2 | tr -d ' '
 }
 
 fatal() {

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -55,10 +55,7 @@ if [ $? -ne 0 ]; then
   echo "  Modifying /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties"
   /bin/cp -p /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties.org.necNfa.$NOW
 
-  ## ファイル末尾に改行がない場合の対処
-  /bin/cat /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties | awk '{print}' > /tmp/msa.$$
-  /bin/cp -p /tmp/msa.$$ /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
-  /bin/rm -f /tmp/msa.$$
+	fixup_no_newline_at_eof /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
 
   echo '70000,"NEC",1' >> /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
 fi
@@ -68,10 +65,7 @@ if [ $? -ne 0 ]; then
   echo "  Modifying /opt/ubi-jentreprise/resources/templates/conf/device/models.properties"
   /bin/cp -p /opt/ubi-jentreprise/resources/templates/conf/device/models.properties /opt/ubi-jentreprise/resources/templates/conf/device/models.properties.org.necNfa.$NOW
 
-  ## ファイル末尾に改行がない場合の対処
-  /bin/cat /opt/ubi-jentreprise/resources/templates/conf/device/models.properties | awk '{print}' > /tmp/msa.$$
-  /bin/cp /tmp/msa.$$ /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
-  /bin/rm -f /tmp/msa.$$
+	fixup_no_newline_at_eof /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
 
   echo '17111602,70000,"NEC NFA","H",0,0,0,0,0,1,0,0,0,0,0,SR,0,0' >> /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
 fi
@@ -86,10 +80,7 @@ if [ $? -ne 0 ]; then
   echo "  Modifying /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties"
   /bin/cp -p /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties.org.necNfa.$NOW
 
-  ## ファイル末尾に改行がない場合の対処
-  /bin/cat /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties | awk '{print}' > /tmp/msa.$$
-  /bin/cp /tmp/msa.$$ /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
-  /bin/rm -f /tmp/msa.$$
+	fixup_no_newline_at_eof /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
 
   echo 'sdExtendedInfo.router.70000-17111602 = necNfa' >> /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
   echo 'sdExtendedInfo.jspType.70000-17111602 = necNfa' >> /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
@@ -175,6 +166,12 @@ fi
 # ----- END COURTESY OF NEC
 }
 
+fixup_no_newline_at_eof() {
+  ## ファイル末尾に改行がない場合の対処
+  /bin/cat "$1" | awk '{print}' > /tmp/msa.$$
+  /bin/cp -p /tmp/msa.$$ "$1"
+  /bin/rm -f /tmp/msa.$$
+}
 
 read_properties_files() {
 	device_properties="conf/device.properties"

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -50,53 +50,77 @@ update_files() {
 DEBUG=$1
 NOW=$(date +"%Y%m%d%H%M")
 
-grep "^70000," /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties > /dev/null
+	update_manufacturers_properties
+	update_models_properties
+	update_sdExtendedInfo_properties
+	update_manageLinks_properties
+	update_ses_properties
+	update_repository_properties
+	do_debug
+}
+
+
+update_manufacturers_properties() {
+	target_file="/opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties"
+grep "^70000," $target_file > /dev/null
 if [ $? -ne 0 ]; then
-  echo "  Modifying /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties"
-  /bin/cp -p /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties.org.necNfa.$NOW
+  echo "  Modifying $target_file"
+  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
 
-	fixup_no_newline_at_eof /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
+	fixup_no_newline_at_eof $target_file
 
-  echo '70000,"NEC",1' >> /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
+  echo '70000,"NEC",1' >> $target_file
 fi
+}
 
-grep "^17111602," /opt/ubi-jentreprise/resources/templates/conf/device/models.properties > /dev/null
+update_models_properties() {
+
+	target_file="/opt/ubi-jentreprise/resources/templates/conf/device/models.properties"
+grep "^17111602," $target_file > /dev/null
 if [ $? -ne 0 ]; then
-  echo "  Modifying /opt/ubi-jentreprise/resources/templates/conf/device/models.properties"
-  /bin/cp -p /opt/ubi-jentreprise/resources/templates/conf/device/models.properties /opt/ubi-jentreprise/resources/templates/conf/device/models.properties.org.necNfa.$NOW
+  echo "  Modifying $target_file"
+  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
 
-	fixup_no_newline_at_eof /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
+	fixup_no_newline_at_eof $target_file
 
-  echo '17111602,70000,"NEC NFA","H",0,0,0,0,0,1,0,0,0,0,0,SR,0,0' >> /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
+  echo '17111602,70000,"NEC NFA","H",0,0,0,0,0,1,0,0,0,0,0,SR,0,0' >> $target_file
+fi
+}
+
+update_sdExtendedInfo_properties() {
+
+	target_file="/opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties"
+if [ ! -f "$target_file" ]; then
+  echo "  Copying $target_file"
+  /bin/cp -p /opt/ses/templates/server_ALL/sdExtendedInfo.properties $target_file
 fi
 
-if [ ! -f "/opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties" ]; then
-  echo "  Copying /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties"
-  /bin/cp -p /opt/ses/templates/server_ALL/sdExtendedInfo.properties /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
-fi
-
-grep "necNfa" /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties > /dev/null
+grep "necNfa" $target_file > /dev/null
 if [ $? -ne 0 ]; then
-  echo "  Modifying /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties"
-  /bin/cp -p /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties.org.necNfa.$NOW
+  echo "  Modifying $target_file"
+  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
 
-	fixup_no_newline_at_eof /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
+	fixup_no_newline_at_eof $target_file
 
-  echo 'sdExtendedInfo.router.70000-17111602 = necNfa' >> /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
-  echo 'sdExtendedInfo.jspType.70000-17111602 = necNfa' >> /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
+  echo 'sdExtendedInfo.router.70000-17111602 = necNfa' >> $target_file
+  echo 'sdExtendedInfo.jspType.70000-17111602 = necNfa' >> $target_file
+fi
+}
+
+update_manageLinks_properties() {
+
+	target_file="/opt/ses/properties/specifics/server_ALL/manageLinks.properties"
+if [ ! -f "$target_file" ]; then
+  echo "  Copying $target_file"
+  /bin/cp -p /opt/ses/templates/server_ALL/manageLinks.properties $target_file
 fi
 
-if [ ! -f "/opt/ses/properties/specifics/server_ALL/manageLinks.properties" ]; then
-  echo "  Copying /opt/ses/properties/specifics/server_ALL/manageLinks.properties"
-  /bin/cp -p /opt/ses/templates/server_ALL/manageLinks.properties /opt/ses/properties/specifics/server_ALL/manageLinks.properties
-fi
-
-grep "necNfa" /opt/ses/properties/specifics/server_ALL/manageLinks.properties > /dev/null
+grep "necNfa" $target_file > /dev/null
 if [ $? -ne 0 ]; then
-  echo "  Modifying /opt/ses/properties/specifics/server_ALL/manageLinks.properties"
-  /bin/cp -p /opt/ses/properties/specifics/server_ALL/manageLinks.properties /opt/ses/properties/specifics/server_ALL/manageLinks.properties.org.necNfa.$NOW
+  echo "  Modifying $target_file"
+  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
 
-  /bin/cat /opt/ses/properties/specifics/server_ALL/manageLinks.properties \
+  /bin/cat $target_file \
     | sed 's/^\(siteLink.initialProv.models.*\)/\1 necNfa/' \
     | sed 's/^\(siteLink.detailedReports.models.*\)/\1 necNfa/' \
     | sed 's/^\(siteLink.displayLogs.models.*\)/\1 necNfa/' \
@@ -107,51 +131,61 @@ if [ $? -ne 0 ]; then
     | sed 's/^\(device.wizard.check.non.empty.credentials.models.*\)/\1 necNfa/' \
     | sed 's/^\(configobjectconsole.supported.models.*\)/\1 necNfa/' \
     > /tmp/msa.$$
-  /bin/cp -p /tmp/msa.$$ /opt/ses/properties/specifics/server_ALL/manageLinks.properties
+  /bin/cp -p /tmp/msa.$$ $target_file
   /bin/rm -f /tmp/msa.$$
 fi
+}
 
-if [ ! -f "/opt/ses/properties/specifics/server_ALL/ses.properties" ]; then
-  echo "  Copying /opt/ses/properties/specifics/server_ALL/ses.properties"
-  /bin/cp -p /opt/ses/templates/server_ALL/ses.properties /opt/ses/properties/specifics/server_ALL/ses.properties
+update_ses_properties() {
+
+	target_file="/opt/ses/properties/specifics/server_ALL/ses.properties"
+if [ ! -f "$target_file" ]; then
+  echo "  Copying $target_file"
+  /bin/cp -p /opt/ses/templates/server_ALL/ses.properties $target_file
 fi
 
-grep "^soc.device.supported.nec" /opt/ses/properties/specifics/server_ALL/ses.properties > /dev/null
+grep "^soc.device.supported.nec" $target_file > /dev/null
 if [ $? -ne 0 ]; then
-  echo "  Modifying /opt/ses/properties/specifics/server_ALL/ses.properties"
-  /bin/cp -p /opt/ses/properties/specifics/server_ALL/ses.properties /opt/ses/properties/specifics/server_ALL/ses.properties.org.necNfa.$NOW
-  echo 'soc.device.supported.nec=1' >> /opt/ses/properties/specifics/server_ALL/ses.properties
+  echo "  Modifying $target_file"
+  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
+  echo 'soc.device.supported.nec=1' >> $target_file
 fi
+}
 
-if [ ! -f "/opt/ses/properties/specifics/server_ALL/repository.properties" ]; then
-  echo "  Copying /opt/ses/properties/specifics/server_ALL/repository.properties"
-  /bin/cp -p /opt/ses/templates/server_ALL/repository.properties /opt/ses/properties/specifics/server_ALL/repository.properties
+update_repository_properties() {
+
+	target_file="/opt/ses/properties/specifics/server_ALL/repository.properties"
+if [ ! -f "$target_file" ]; then
+  echo "  Copying $target_file"
+  /bin/cp -p /opt/ses/templates/server_ALL/repository.properties $target_file
 fi
 
 CP_DONE=0
-grep "^repository.manufacturer.* NEC.*" /opt/ses/properties/specifics/server_ALL/repository.properties > /dev/null
+grep "^repository.manufacturer.* NEC.*" $target_file > /dev/null
 if [ $? -ne 0 ]; then
-  echo "  Modifying(1) /opt/ses/properties/specifics/server_ALL/repository.properties"
-  /bin/cp -p /opt/ses/properties/specifics/server_ALL/repository.properties /opt/ses/properties/specifics/server_ALL/repository.properties.org.necNfa.$NOW
+  echo "  Modifying(1) $target_file"
+  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
   CP_DONE=1
-  /bin/cat /opt/ses/properties/specifics/server_ALL/repository.properties \
+  /bin/cat $target_file \
     | sed 's/^\(repository.manufacturer.*\)/\1 NEC/' \
     > /tmp/msa.$$
-  /bin/cp -p /tmp/msa.$$ /opt/ses/properties/specifics/server_ALL/repository.properties
+  /bin/cp -p /tmp/msa.$$ $target_file
   /bin/rm -f /tmp/msa.$$
 fi
 
-grep "^repository.access.nec=" /opt/ses/properties/specifics/server_ALL/repository.properties > /dev/null
+grep "^repository.access.nec=" $target_file > /dev/null
 if [ $? -ne 0 ]; then
-  echo "  Modifying(2) /opt/ses/properties/specifics/server_ALL/repository.properties"
+  echo "  Modifying(2) $target_file"
   if [ $CP_DONE -eq 0 ]; then
-    /bin/cp -p /opt/ses/properties/specifics/server_ALL/repository.properties /opt/ses/properties/specifics/server_ALL/repository.properties.org.necNfa.$NOW
+    /bin/cp -p $target_file $target_file.org.necNfa.$NOW
     CP_DONE=1
   fi
-  echo 'repository.model.nec=70000-17072801 70000-17111601 70000-17111602' >> /opt/ses/properties/specifics/server_ALL/repository.properties
-  echo 'repository.access.nec=|Configuration|Firmware|CommandDefinition|Datafiles|Reports|License|Orchestration|Process|' >> /opt/ses/properties/specifics/server_ALL/repository.properties
+  echo 'repository.model.nec=70000-17072801 70000-17111601 70000-17111602' >> $target_file
+  echo 'repository.access.nec=|Configuration|Firmware|CommandDefinition|Datafiles|Reports|License|Orchestration|Process|' >> $target_file
 fi
+}
 
+do_debug() {
 ## for debug
 if [ "$DEBUG" == "debug" ]; then
   echo

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -43,6 +43,138 @@ da_uninstall() {
 	:;
 }
 
+update_files() {
+
+# ----- COURTESY OF NEC
+
+DEBUG=$1
+NOW=$(date +"%Y%m%d%H%M")
+
+grep "^70000," /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties > /dev/null
+if [ $? -ne 0 ]; then
+  echo "  Modifying /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties"
+  /bin/cp -p /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties.org.necNfa.$NOW
+
+  ## ファイル末尾に改行がない場合の対処
+  /bin/cat /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties | awk '{print}' > /tmp/msa.$$
+  /bin/cp -p /tmp/msa.$$ /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
+  /bin/rm -f /tmp/msa.$$
+
+  echo '70000,"NEC",1' >> /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
+fi
+
+grep "^17111602," /opt/ubi-jentreprise/resources/templates/conf/device/models.properties > /dev/null
+if [ $? -ne 0 ]; then
+  echo "  Modifying /opt/ubi-jentreprise/resources/templates/conf/device/models.properties"
+  /bin/cp -p /opt/ubi-jentreprise/resources/templates/conf/device/models.properties /opt/ubi-jentreprise/resources/templates/conf/device/models.properties.org.necNfa.$NOW
+
+  ## ファイル末尾に改行がない場合の対処
+  /bin/cat /opt/ubi-jentreprise/resources/templates/conf/device/models.properties | awk '{print}' > /tmp/msa.$$
+  /bin/cp /tmp/msa.$$ /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
+  /bin/rm -f /tmp/msa.$$
+
+  echo '17111602,70000,"NEC NFA","H",0,0,0,0,0,1,0,0,0,0,0,SR,0,0' >> /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
+fi
+
+if [ ! -f "/opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties" ]; then
+  echo "  Copying /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties"
+  /bin/cp -p /opt/ses/templates/server_ALL/sdExtendedInfo.properties /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
+fi
+
+grep "necNfa" /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties > /dev/null
+if [ $? -ne 0 ]; then
+  echo "  Modifying /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties"
+  /bin/cp -p /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties.org.necNfa.$NOW
+
+  ## ファイル末尾に改行がない場合の対処
+  /bin/cat /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties | awk '{print}' > /tmp/msa.$$
+  /bin/cp /tmp/msa.$$ /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
+  /bin/rm -f /tmp/msa.$$
+
+  echo 'sdExtendedInfo.router.70000-17111602 = necNfa' >> /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
+  echo 'sdExtendedInfo.jspType.70000-17111602 = necNfa' >> /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
+fi
+
+if [ ! -f "/opt/ses/properties/specifics/server_ALL/manageLinks.properties" ]; then
+  echo "  Copying /opt/ses/properties/specifics/server_ALL/manageLinks.properties"
+  /bin/cp -p /opt/ses/templates/server_ALL/manageLinks.properties /opt/ses/properties/specifics/server_ALL/manageLinks.properties
+fi
+
+grep "necNfa" /opt/ses/properties/specifics/server_ALL/manageLinks.properties > /dev/null
+if [ $? -ne 0 ]; then
+  echo "  Modifying /opt/ses/properties/specifics/server_ALL/manageLinks.properties"
+  /bin/cp -p /opt/ses/properties/specifics/server_ALL/manageLinks.properties /opt/ses/properties/specifics/server_ALL/manageLinks.properties.org.necNfa.$NOW
+
+  /bin/cat /opt/ses/properties/specifics/server_ALL/manageLinks.properties \
+    | sed 's/^\(siteLink.initialProv.models.*\)/\1 necNfa/' \
+    | sed 's/^\(siteLink.detailedReports.models.*\)/\1 necNfa/' \
+    | sed 's/^\(siteLink.displayLogs.models.*\)/\1 necNfa/' \
+    | sed 's/^\(device.wizard.authentication.window.models.*\)/\1 necNfa/' \
+    | sed 's/^\(device.cisco.license.manager.models.*\)/\1 necNfa/' \
+    | sed 's/^\(device.wizard.managecertificate.models.*\)/\1 necNfa/' \
+    | sed 's/^\(device.wizard.specific.rules.and.commands.models.*\)/\1 necNfa/' \
+    | sed 's/^\(device.wizard.check.non.empty.credentials.models.*\)/\1 necNfa/' \
+    | sed 's/^\(configobjectconsole.supported.models.*\)/\1 necNfa/' \
+    > /tmp/msa.$$
+  /bin/cp -p /tmp/msa.$$ /opt/ses/properties/specifics/server_ALL/manageLinks.properties
+  /bin/rm -f /tmp/msa.$$
+fi
+
+if [ ! -f "/opt/ses/properties/specifics/server_ALL/ses.properties" ]; then
+  echo "  Copying /opt/ses/properties/specifics/server_ALL/ses.properties"
+  /bin/cp -p /opt/ses/templates/server_ALL/ses.properties /opt/ses/properties/specifics/server_ALL/ses.properties
+fi
+
+grep "^soc.device.supported.nec" /opt/ses/properties/specifics/server_ALL/ses.properties > /dev/null
+if [ $? -ne 0 ]; then
+  echo "  Modifying /opt/ses/properties/specifics/server_ALL/ses.properties"
+  /bin/cp -p /opt/ses/properties/specifics/server_ALL/ses.properties /opt/ses/properties/specifics/server_ALL/ses.properties.org.necNfa.$NOW
+  echo 'soc.device.supported.nec=1' >> /opt/ses/properties/specifics/server_ALL/ses.properties
+fi
+
+if [ ! -f "/opt/ses/properties/specifics/server_ALL/repository.properties" ]; then
+  echo "  Copying /opt/ses/properties/specifics/server_ALL/repository.properties"
+  /bin/cp -p /opt/ses/templates/server_ALL/repository.properties /opt/ses/properties/specifics/server_ALL/repository.properties
+fi
+
+CP_DONE=0
+grep "^repository.manufacturer.* NEC.*" /opt/ses/properties/specifics/server_ALL/repository.properties > /dev/null
+if [ $? -ne 0 ]; then
+  echo "  Modifying(1) /opt/ses/properties/specifics/server_ALL/repository.properties"
+  /bin/cp -p /opt/ses/properties/specifics/server_ALL/repository.properties /opt/ses/properties/specifics/server_ALL/repository.properties.org.necNfa.$NOW
+  CP_DONE=1
+  /bin/cat /opt/ses/properties/specifics/server_ALL/repository.properties \
+    | sed 's/^\(repository.manufacturer.*\)/\1 NEC/' \
+    > /tmp/msa.$$
+  /bin/cp -p /tmp/msa.$$ /opt/ses/properties/specifics/server_ALL/repository.properties
+  /bin/rm -f /tmp/msa.$$
+fi
+
+grep "^repository.access.nec=" /opt/ses/properties/specifics/server_ALL/repository.properties > /dev/null
+if [ $? -ne 0 ]; then
+  echo "  Modifying(2) /opt/ses/properties/specifics/server_ALL/repository.properties"
+  if [ $CP_DONE -eq 0 ]; then
+    /bin/cp -p /opt/ses/properties/specifics/server_ALL/repository.properties /opt/ses/properties/specifics/server_ALL/repository.properties.org.necNfa.$NOW
+    CP_DONE=1
+  fi
+  echo 'repository.model.nec=70000-17072801 70000-17111601 70000-17111602' >> /opt/ses/properties/specifics/server_ALL/repository.properties
+  echo 'repository.access.nec=|Configuration|Firmware|CommandDefinition|Datafiles|Reports|License|Orchestration|Process|' >> /opt/ses/properties/specifics/server_ALL/repository.properties
+fi
+
+## for debug
+if [ "$DEBUG" == "debug" ]; then
+  echo
+  diff -u /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties.org.necNfa.$NOW /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
+  diff -u /opt/ubi-jentreprise/resources/templates/conf/device/models.properties.org.necNfa.$NOW /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
+  diff -u /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties.org.necNfa.$NOW /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
+  diff -u /opt/ses/properties/specifics/server_ALL/manageLinks.properties.org.necNfa.$NOW /opt/ses/properties/specifics/server_ALL/manageLinks.properties
+  diff -u /opt/ses/properties/specifics/server_ALL/ses.properties.org.necNfa.$NOW /opt/ses/properties/specifics/server_ALL/ses.properties
+  diff -u /opt/ses/properties/specifics/server_ALL/repository.properties.org.necNfa.$NOW /opt/ses/properties/specifics/server_ALL/repository.properties
+fi
+
+# ----- END COURTESY OF NEC
+}
+
 
 read_properties_files() {
 	device_properties="conf/device.properties"

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#set -x
+
+PROG=$(basename $0)
+
+usage() {
+	echo "usage: $PROG <install|uninstall> <device adaptor directory>"
+	echo
+	echo "install or un-install MSA device adaptors"
+}
+
+main() {
+	cmd=$1
+	shift
+	case $cmd in
+		""|-h|--help)
+			usage
+			;;
+		-i|install)
+			da_install "$1"
+			;;
+		-u|uninstall)
+			da_uninstall "$1"
+			;;
+		*)
+			fatal "unknown command: $1"
+			;;
+	esac
+}
+
+da_install() {
+	:;
+}
+
+da_uninstall() {
+	:;
+}
+
+fatal() {
+	echo $* >&2
+	exit 1
+}
+
+
+main "$@"

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -239,6 +239,14 @@ read_property() {
 	cat $DA_DIR/$file | egrep "^$prop" | cut -d = -f 2 | tr -d ' '
 }
 
+tolower() {
+	echo $1 | tr '[A-Z]' '[a-z]'
+}
+
+toupper() {
+	echo $1 | tr '[a-z]' '[A-Z]'
+}
+
 fatal() {
 	echo $* >&2
 	exit 1

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -47,7 +47,6 @@ update_files() {
 
 # ----- COURTESY OF NEC
 
-DEBUG=$1
 NOW=$(date +"%Y%m%d%H%M")
 
 	update_manufacturers_properties
@@ -56,7 +55,6 @@ NOW=$(date +"%Y%m%d%H%M")
 	update_manageLinks_properties
 	update_ses_properties
 	update_repository_properties
-	do_debug
 }
 
 
@@ -185,20 +183,7 @@ if [ $? -ne 0 ]; then
 fi
 }
 
-do_debug() {
-## for debug
-if [ "$DEBUG" == "debug" ]; then
-  echo
-  diff -u /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties.org.necNfa.$NOW /opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties
-  diff -u /opt/ubi-jentreprise/resources/templates/conf/device/models.properties.org.necNfa.$NOW /opt/ubi-jentreprise/resources/templates/conf/device/models.properties
-  diff -u /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties.org.necNfa.$NOW /opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties
-  diff -u /opt/ses/properties/specifics/server_ALL/manageLinks.properties.org.necNfa.$NOW /opt/ses/properties/specifics/server_ALL/manageLinks.properties
-  diff -u /opt/ses/properties/specifics/server_ALL/ses.properties.org.necNfa.$NOW /opt/ses/properties/specifics/server_ALL/ses.properties
-  diff -u /opt/ses/properties/specifics/server_ALL/repository.properties.org.necNfa.$NOW /opt/ses/properties/specifics/server_ALL/repository.properties
-fi
 
-# ----- END COURTESY OF NEC
-}
 
 fixup_no_newline_at_eof() {
   ## ファイル末尾に改行がない場合の対処

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -36,7 +36,9 @@ da_install() {
 
 	read_properties_files
 	check_sms_router_conf
-	:;
+
+	check_create_files
+	update_files
 }
 
 da_uninstall() {
@@ -44,11 +46,6 @@ da_uninstall() {
 }
 
 update_files() {
-
-# ----- COURTESY OF NEC
-
-NOW=$(date +"%Y%m%d%H%M")
-
 	update_manufacturers_properties
 	update_models_properties
 	update_sdExtendedInfo_properties
@@ -58,129 +55,113 @@ NOW=$(date +"%Y%m%d%H%M")
 }
 
 
-update_manufacturers_properties() {
-	target_file="/opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties"
-	grep -q "^70000," $target_file && return 0
+JENTREPRISE_CONF="/opt/ubi-jentreprise/resources/templates/conf/device"
+SES_TEMPLATE="/opt/ses/templates/server_ALL"
+SES_CONF="/opt/ses/properties/specifics/server_ALL"
 
-  echo "  Modifying $target_file"
-  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
+
+check_create_files() {
+
+	for prop_file in ses repository sdExtendedInfo manageLinks; do
+		target_file="$SES_CONF/$prop_file.properties"
+
+		[ -f "$target_file" ] && continue
+
+		echo "  Copying $target_file"
+		/bin/cp -p $SES_TEMPLATE/$prop_file.properties $target_file
+	done
+}
+
+
+update_manufacturers_properties() {
+
+	target_file="$JENTREPRISE_CONF/manufacturers.properties"
+	grep -q "^$MAN_ID," $target_file && return 0
 
 	fixup_no_newline_at_eof $target_file
 
-  echo '70000,"NEC",1' >> $target_file
+	echo $MAN_ID',"'$MAN_NAME'",1' >> $target_file
 
 }
 
 update_models_properties() {
 
-	target_file="/opt/ubi-jentreprise/resources/templates/conf/device/models.properties"
-	grep -q "^17111602," $target_file && return 0
-
-  echo "  Modifying $target_file"
-  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
+	target_file="$JENTREPRISE_CONF/models.properties"
+	grep -q "^$MOD_ID," $target_file && return 0
 
 	fixup_no_newline_at_eof $target_file
 
-  echo '17111602,70000,"NEC NFA","H",0,0,0,0,0,1,0,0,0,0,0,SR,0,0' >> $target_file
+	echo $MOD_ID,$MAN_ID,'"'$MOD_NAME'","H",0,0,0,0,0,1,0,0,0,0,0,SR,0,0' >> $target_file
 
 }
 
 update_sdExtendedInfo_properties() {
 
-	target_file="/opt/ses/properties/specifics/server_ALL/sdExtendedInfo.properties"
-if [ ! -f "$target_file" ]; then
-  echo "  Copying $target_file"
-  /bin/cp -p /opt/ses/templates/server_ALL/sdExtendedInfo.properties $target_file
-fi
+	target_file="$SES_CONF/sdExtendedInfo.properties"
 
-	grep -q "necNfa" $target_file && return 0
+	keyname="${MAN_NAME}${MOD_NAME}"
+	deviceid="${MAN_ID}-${MOD_ID}"
 
-  echo "  Modifying $target_file"
-  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
+	grep -q "$keyname" $target_file && return 0
 
 	fixup_no_newline_at_eof $target_file
 
-  echo 'sdExtendedInfo.router.70000-17111602 = necNfa' >> $target_file
-  echo 'sdExtendedInfo.jspType.70000-17111602 = necNfa' >> $target_file
+	echo "sdExtendedInfo.modelKey.$keyname = $keyname" >> $target_file
+	echo "sdExtendedInfo.router.$deviceid = $keyname" >> $target_file
+	echo "sdExtendedInfo.jspType.$deviceid = $keyname" >> $target_file
 
 }
 
 update_manageLinks_properties() {
 
-	target_file="/opt/ses/properties/specifics/server_ALL/manageLinks.properties"
-if [ ! -f "$target_file" ]; then
-  echo "  Copying $target_file"
-  /bin/cp -p /opt/ses/templates/server_ALL/manageLinks.properties $target_file
-fi
+	target_file="$SES_CONF/manageLinks.properties"
 
-	grep -q "necNfa" $target_file && return 0
+	keyname="${MAN_NAME}${MOD_NAME}"
 
-  echo "  Modifying $target_file"
-  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
+	grep -q "$keyname" $target_file && return 0
 
-  /bin/cat $target_file \
-    | sed 's/^\(siteLink.initialProv.models.*\)/\1 necNfa/' \
-    | sed 's/^\(siteLink.detailedReports.models.*\)/\1 necNfa/' \
-    | sed 's/^\(siteLink.displayLogs.models.*\)/\1 necNfa/' \
-    | sed 's/^\(device.wizard.authentication.window.models.*\)/\1 necNfa/' \
-    | sed 's/^\(device.cisco.license.manager.models.*\)/\1 necNfa/' \
-    | sed 's/^\(device.wizard.managecertificate.models.*\)/\1 necNfa/' \
-    | sed 's/^\(device.wizard.specific.rules.and.commands.models.*\)/\1 necNfa/' \
-    | sed 's/^\(device.wizard.check.non.empty.credentials.models.*\)/\1 necNfa/' \
-    | sed 's/^\(configobjectconsole.supported.models.*\)/\1 necNfa/' \
-    > /tmp/msa.$$
-  /bin/cp -p /tmp/msa.$$ $target_file
-  /bin/rm -f /tmp/msa.$$
+	dafile="$DA_DIR/conf/features.properties"
+	cat $dafile | grep -e "= *yes" | while read line; do
+		prop=$(sed 's: *=.*::g' <<< "$line")
+		grep -q "$prop" $target_file || \
+			echo "$prop.models = " >> $target_file
+		sed -i "s:^\($prop.models.*\):\1 $keyname:"  $target_file
+	done
 
 }
 
 update_ses_properties() {
 
-	target_file="/opt/ses/properties/specifics/server_ALL/ses.properties"
-if [ ! -f "$target_file" ]; then
-  echo "  Copying $target_file"
-  /bin/cp -p /opt/ses/templates/server_ALL/ses.properties $target_file
-fi
+	target_file="$SES_CONF/ses.properties"
 
-	grep -q "^soc.device.supported.nec" $target_file && return 0
+	keyname=$(tolower $MAN_NAME)
 
-  echo "  Modifying $target_file"
-  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
-  echo 'soc.device.supported.nec=1' >> $target_file
+	grep -q "^soc.device.supported.$keyname" $target_file && return 0
+
+	echo "soc.device.supported.$keyname=1" >> $target_file
 
 }
 
 update_repository_properties() {
 
-	target_file="/opt/ses/properties/specifics/server_ALL/repository.properties"
-if [ ! -f "$target_file" ]; then
-  echo "  Copying $target_file"
-  /bin/cp -p /opt/ses/templates/server_ALL/repository.properties $target_file
-fi
+	target_file="$SES_CONF/repository.properties"
 
-CP_DONE=0
-grep "^repository.manufacturer.* NEC.*" $target_file > /dev/null
-if [ $? -ne 0 ]; then
-  echo "  Modifying(1) $target_file"
-  /bin/cp -p $target_file $target_file.org.necNfa.$NOW
-  CP_DONE=1
-  /bin/cat $target_file \
-    | sed 's/^\(repository.manufacturer.*\)/\1 NEC/' \
-    > /tmp/msa.$$
-  /bin/cp -p /tmp/msa.$$ $target_file
-  /bin/rm -f /tmp/msa.$$
-fi
+	keyname=$(toupper $MAN_NAME)
 
-grep "^repository.access.nec=" $target_file > /dev/null
-if [ $? -ne 0 ]; then
-  echo "  Modifying(2) $target_file"
-  if [ $CP_DONE -eq 0 ]; then
-    /bin/cp -p $target_file $target_file.org.necNfa.$NOW
-    CP_DONE=1
-  fi
-  echo 'repository.model.nec=70000-17072801 70000-17111601 70000-17111602' >> $target_file
-  echo 'repository.access.nec=|Configuration|Firmware|CommandDefinition|Datafiles|Reports|License|Orchestration|Process|' >> $target_file
-fi
+	grep -q "^repository.manufacturer *= *.* $keyname" $target_file || \
+		sed -i 's/^\(repository.manufacturer.*\)/\1'" $keyname/"  $target_file
+
+	keyname=$(tolower $MAN_NAME)
+	deviceid="${MAN_ID}-${MOD_ID}"
+
+	grep -q "^repository.model.$keyname" $target_file || \
+		echo "repository.model.$keyname=$deviceid" >> $target_file
+
+	dafile="$DA_DIR/conf/repository.properties"
+	props="|$(cat $dafile | grep yes | awk '{printf $1 "|"}')"
+
+	grep -q "^repository.access.$keyname" $target_file || \
+		echo "repository.access.$keyname=|$props" >> $target_file
 }
 
 

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -62,29 +62,29 @@ NOW=$(date +"%Y%m%d%H%M")
 
 update_manufacturers_properties() {
 	target_file="/opt/ubi-jentreprise/resources/templates/conf/device/manufacturers.properties"
-grep "^70000," $target_file > /dev/null
-if [ $? -ne 0 ]; then
+	grep -q "^70000," $target_file && return 0
+
   echo "  Modifying $target_file"
   /bin/cp -p $target_file $target_file.org.necNfa.$NOW
 
 	fixup_no_newline_at_eof $target_file
 
   echo '70000,"NEC",1' >> $target_file
-fi
+
 }
 
 update_models_properties() {
 
 	target_file="/opt/ubi-jentreprise/resources/templates/conf/device/models.properties"
-grep "^17111602," $target_file > /dev/null
-if [ $? -ne 0 ]; then
+	grep -q "^17111602," $target_file && return 0
+
   echo "  Modifying $target_file"
   /bin/cp -p $target_file $target_file.org.necNfa.$NOW
 
 	fixup_no_newline_at_eof $target_file
 
   echo '17111602,70000,"NEC NFA","H",0,0,0,0,0,1,0,0,0,0,0,SR,0,0' >> $target_file
-fi
+
 }
 
 update_sdExtendedInfo_properties() {
@@ -95,8 +95,8 @@ if [ ! -f "$target_file" ]; then
   /bin/cp -p /opt/ses/templates/server_ALL/sdExtendedInfo.properties $target_file
 fi
 
-grep "necNfa" $target_file > /dev/null
-if [ $? -ne 0 ]; then
+	grep -q "necNfa" $target_file && return 0
+
   echo "  Modifying $target_file"
   /bin/cp -p $target_file $target_file.org.necNfa.$NOW
 
@@ -104,7 +104,7 @@ if [ $? -ne 0 ]; then
 
   echo 'sdExtendedInfo.router.70000-17111602 = necNfa' >> $target_file
   echo 'sdExtendedInfo.jspType.70000-17111602 = necNfa' >> $target_file
-fi
+
 }
 
 update_manageLinks_properties() {
@@ -115,8 +115,8 @@ if [ ! -f "$target_file" ]; then
   /bin/cp -p /opt/ses/templates/server_ALL/manageLinks.properties $target_file
 fi
 
-grep "necNfa" $target_file > /dev/null
-if [ $? -ne 0 ]; then
+	grep -q "necNfa" $target_file && return 0
+
   echo "  Modifying $target_file"
   /bin/cp -p $target_file $target_file.org.necNfa.$NOW
 
@@ -133,7 +133,7 @@ if [ $? -ne 0 ]; then
     > /tmp/msa.$$
   /bin/cp -p /tmp/msa.$$ $target_file
   /bin/rm -f /tmp/msa.$$
-fi
+
 }
 
 update_ses_properties() {
@@ -144,12 +144,12 @@ if [ ! -f "$target_file" ]; then
   /bin/cp -p /opt/ses/templates/server_ALL/ses.properties $target_file
 fi
 
-grep "^soc.device.supported.nec" $target_file > /dev/null
-if [ $? -ne 0 ]; then
+	grep -q "^soc.device.supported.nec" $target_file && return 0
+
   echo "  Modifying $target_file"
   /bin/cp -p $target_file $target_file.org.necNfa.$NOW
   echo 'soc.device.supported.nec=1' >> $target_file
-fi
+
 }
 
 update_repository_properties() {


### PR DESCRIPTION
The installer script:
- adds a new adaptor definition to various system-global MSA configuration files
- uses adaptor information defined in unitary properties files

The unitary properties files:
- define the facets of the adaptor
- provide for the plug into system-global configuration files
- => see [sample conf](../tree/device_adaptor_installer/vmware_vsphere/conf)