### PR TITLE
Update paloalto_generic_connect.php

### DIFF
--- a/paloalto_generic/paloalto_generic_connect.php
+++ b/paloalto_generic/paloalto_generic_connect.php
@@ -210,7 +210,9 @@ class DeviceConnection extends GenericConnection
   	{
         $net_pf = get_network_profile();
         $sd =&$net_pf->SD;
-        $palo_retry_show_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+       // $palo_retry_show_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+	$palo_retry_configured_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+    	$palo_retry_show_limit = $palo_retry_configured_limit;
         if(empty($palo_retry_show_limit)) {
           $palo_retry_show_limit = 5; //default
         }
@@ -219,6 +221,14 @@ class DeviceConnection extends GenericConnection
 
         do
         {
+	if ($palo_retry_show_limit <= 0) 
+		{
+		sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after . '$palo_retry_configured_limit . 'times (no status FIN received)');
+		break;
+		}	
+        $palo_retry_show_limit--;
+		
+		
           sleep(2);
 
           try


### PR DESCRIPTION
Changed the way the variable $palo_retry_show_limit is used in order to make sure we don't fall into an infinite loop when not receiving the FIN job status line 264