### PR TITLE
Update paloalto_generic {apply_conf,connect}.php to avoid infinite loop

### DIFF
--- a/paloalto_generic/paloalto_generic_apply_conf.php
+++ b/paloalto_generic/paloalto_generic_apply_conf.php
@@ -79,17 +79,17 @@ function paloalto_generic_apply_conf($configuration)
     $last_result = null;
     do
     {
-	if ($palo_retry_show_limit <= 0) 
-	{
-		sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after . '$palo_retry_configured_limit . 'times (no status FIN received)');
-		break;
-	}	
-        $palo_retry_show_limit--;
-	    
-      	sleep(2);
-      	try {
-        	$result = sendexpectone(__FILE__ . ':' . __LINE__, $sms_sd_ctx, 'type=op&cmd='.urlencode("<show><jobs><id>{$job}</id></jobs></show>"));
-        	if (!empty($operation) && $result->result->job->status == 'ACT')
+      if ($palo_retry_show_limit <= 0)
+      {
+        sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after .'$palo_retry_configured_limit . 'times (no status FIN received)');
+        break;
+      }
+      $palo_retry_show_limit--;
+
+      sleep(2);
+      try {
+        $result = sendexpectone(__FILE__ . ':' . __LINE__, $sms_sd_ctx, 'type=op&cmd='.urlencode("<show><jobs><id>{$job}</id></jobs></show>"));
+        if (!empty($operation) && $result->result->job->status == 'ACT')
         {
           status_progress("progress {$result->result->job->progress}%", $operation);
         }

--- a/paloalto_generic/paloalto_generic_apply_conf.php
+++ b/paloalto_generic/paloalto_generic_apply_conf.php
@@ -81,7 +81,7 @@ function paloalto_generic_apply_conf($configuration)
     {
       if ($palo_retry_show_limit <= 0)
       {
-        sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after .'$palo_retry_configured_limit . 'times (no status FIN received)');
+        sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after ' . $palo_retry_configured_limit . ' times (no status FIN received)');
         break;
       }
       $palo_retry_show_limit--;

--- a/paloalto_generic/paloalto_generic_apply_conf.php
+++ b/paloalto_generic/paloalto_generic_apply_conf.php
@@ -70,7 +70,8 @@ function paloalto_generic_apply_conf($configuration)
     $job = $result->result->job;
     $net_pf = get_network_profile();
     $sd =&$net_pf->SD;
-    $palo_retry_show_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+    $palo_retry_configured_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+    $palo_retry_show_limit = $palo_retry_configured_limit;
     if(empty($palo_retry_show_limit)) {
       $palo_retry_show_limit = 5; //default
     }
@@ -78,18 +79,25 @@ function paloalto_generic_apply_conf($configuration)
     $last_result = null;
     do
     {
-      sleep(2);
-      try {
-        $result = sendexpectone(__FILE__ . ':' . __LINE__, $sms_sd_ctx, 'type=op&cmd='.urlencode("<show><jobs><id>{$job}</id></jobs></show>"));
-        if (!empty($operation) && $result->result->job->status == 'ACT')
+	if ($palo_retry_show_limit <= 0) 
+	{
+		sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after . '$palo_retry_configured_limit . 'times (no status FIN received)');
+		break;
+	}	
+        $palo_retry_show_limit--;
+	    
+      	sleep(2);
+      	try {
+        	$result = sendexpectone(__FILE__ . ':' . __LINE__, $sms_sd_ctx, 'type=op&cmd='.urlencode("<show><jobs><id>{$job}</id></jobs></show>"));
+        	if (!empty($operation) && $result->result->job->status == 'ACT')
         {
           status_progress("progress {$result->result->job->progress}%", $operation);
         }
         $last_result = $result; //store the response
       } catch (Exception $e) {
         sms_log_info($e->getMessage());
-        if ($palo_retry_show_limit > 0) {
-          $palo_retry_show_limit--;
+       // if ($palo_retry_show_limit > 0) {
+       //   $palo_retry_show_limit--;
           if(!empty($last_result)) {
             //check the warning contents of last show response
             $warnings = $last_result->result->job->warnings;
@@ -102,7 +110,7 @@ function paloalto_generic_apply_conf($configuration)
               }
             }
           }
-        }
+       // }
         throw $e;
       }
     } while ($result->result->job->status != 'FIN');

--- a/paloalto_generic/paloalto_generic_apply_conf.php
+++ b/paloalto_generic/paloalto_generic_apply_conf.php
@@ -96,8 +96,6 @@ function paloalto_generic_apply_conf($configuration)
         $last_result = $result; //store the response
       } catch (Exception $e) {
         sms_log_info($e->getMessage());
-       // if ($palo_retry_show_limit > 0) {
-       //   $palo_retry_show_limit--;
           if(!empty($last_result)) {
             //check the warning contents of last show response
             $warnings = $last_result->result->job->warnings;
@@ -110,7 +108,6 @@ function paloalto_generic_apply_conf($configuration)
               }
             }
           }
-       // }
         throw $e;
       }
     } while ($result->result->job->status != 'FIN');

--- a/paloalto_generic/paloalto_generic_connect.php
+++ b/paloalto_generic/paloalto_generic_connect.php
@@ -210,7 +210,6 @@ class DeviceConnection extends GenericConnection
   	{
         $net_pf = get_network_profile();
         $sd =&$net_pf->SD;
-       // $palo_retry_show_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
         $palo_retry_configured_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
         $palo_retry_show_limit = $palo_retry_configured_limit;
         if(empty($palo_retry_show_limit)) {

--- a/paloalto_generic/paloalto_generic_connect.php
+++ b/paloalto_generic/paloalto_generic_connect.php
@@ -243,8 +243,6 @@ class DeviceConnection extends GenericConnection
           catch (Exception $e)
           {
             sms_log_info($e->getMessage());
-            if ($palo_retry_show_limit > 0) {
-              $palo_retry_show_limit--;
               if(!empty($last_result)) {
                 //check the warning contents of last show response
                 $warnings = $last_result->result->job->warnings;
@@ -257,7 +255,6 @@ class DeviceConnection extends GenericConnection
                   }
                 }
               }
-            }
             throw $e;
           }
         } while ($result->result->job->status != 'FIN');

--- a/paloalto_generic/paloalto_generic_connect.php
+++ b/paloalto_generic/paloalto_generic_connect.php
@@ -210,7 +210,9 @@ class DeviceConnection extends GenericConnection
   	{
         $net_pf = get_network_profile();
         $sd =&$net_pf->SD;
-        $palo_retry_show_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+       // $palo_retry_show_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+	$palo_retry_configured_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+    	$palo_retry_show_limit = $palo_retry_configured_limit;
         if(empty($palo_retry_show_limit)) {
           $palo_retry_show_limit = 5; //default
         }
@@ -219,6 +221,14 @@ class DeviceConnection extends GenericConnection
 
         do
         {
+	if ($palo_retry_show_limit <= 0) 
+		{
+		sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after . '$palo_retry_configured_limit . 'times (no status FIN received)');
+		break;
+		}	
+        $palo_retry_show_limit--;
+		
+		
           sleep(2);
 
           try

--- a/paloalto_generic/paloalto_generic_connect.php
+++ b/paloalto_generic/paloalto_generic_connect.php
@@ -211,8 +211,8 @@ class DeviceConnection extends GenericConnection
         $net_pf = get_network_profile();
         $sd =&$net_pf->SD;
        // $palo_retry_show_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
-	$palo_retry_configured_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
-    	$palo_retry_show_limit = $palo_retry_configured_limit;
+        $palo_retry_configured_limit = $sd->SD_CONFIGVAR_list['palo_retry_show_limit']->VAR_VALUE;
+        $palo_retry_show_limit = $palo_retry_configured_limit;
         if(empty($palo_retry_show_limit)) {
           $palo_retry_show_limit = 5; //default
         }
@@ -221,14 +221,14 @@ class DeviceConnection extends GenericConnection
 
         do
         {
-	if ($palo_retry_show_limit <= 0) 
-		{
-		sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after . '$palo_retry_configured_limit . 'times (no status FIN received)');
-		break;
-		}	
-        $palo_retry_show_limit--;
-		
-		
+          if ($palo_retry_show_limit <= 0)
+          {
+            sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after . '$palo_retry_configured_limit . 'times (no status FIN received)');
+            break;
+          }
+          $palo_retry_show_limit--;
+
+
           sleep(2);
 
           try

--- a/paloalto_generic/paloalto_generic_connect.php
+++ b/paloalto_generic/paloalto_generic_connect.php
@@ -222,7 +222,7 @@ class DeviceConnection extends GenericConnection
         {
           if ($palo_retry_show_limit <= 0)
           {
-            sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after . '$palo_retry_configured_limit . 'times (no status FIN received)');
+            sms_log_error(__FILE__ . ':' . __LINE__ . ' : Giving up after ' . $palo_retry_configured_limit . ' times (no status FIN received)');
             break;
           }
           $palo_retry_show_limit--;


### PR DESCRIPTION
Change the way the variable $palo_retry_show_limit is used to make sure we don't fall into an infinite loop when not receiving the FIN job status.

Fixes #19