### PR TITLE
Fix json encode for import

### DIFF
--- a/a10_thunder/a10_thunder_command.php
+++ b/a10_thunder/a10_thunder_command.php
@@ -89,7 +89,7 @@ class a10_thunder_command extends generic_command {
                 $this->parsed_objects = $objects;
 
                 debug_object_conf($objects);
-                $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+                $SMS_RETURN_BUF .= object_to_json($objects);
             }
 
             sd_disconnect();
@@ -146,7 +146,7 @@ class a10_thunder_command extends generic_command {
             $this->parsed_objects = $objects;
 
             debug_object_conf($objects);
-            $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+            $SMS_RETURN_BUF .= object_to_json($objects);
         }
 
         return SMS_OK;

--- a/a10_thunder/a10_thunder_command.php
+++ b/a10_thunder/a10_thunder_command.php
@@ -89,7 +89,7 @@ class a10_thunder_command extends generic_command {
                 $this->parsed_objects = $objects;
 
                 debug_object_conf($objects);
-                $SMS_RETURN_BUF .= json_encode($objects);
+                $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
             }
 
             sd_disconnect();
@@ -146,7 +146,7 @@ class a10_thunder_command extends generic_command {
             $this->parsed_objects = $objects;
 
             debug_object_conf($objects);
-            $SMS_RETURN_BUF .= json_encode($objects);
+            $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
         }
 
         return SMS_OK;

--- a/a10_thunder_axapi/a10_thunder_axapi_command.php
+++ b/a10_thunder_axapi/a10_thunder_axapi_command.php
@@ -107,7 +107,7 @@ class a10_thunder_axapi_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/a10_thunder_axapi/a10_thunder_axapi_command.php
+++ b/a10_thunder_axapi/a10_thunder_axapi_command.php
@@ -107,7 +107,7 @@ class a10_thunder_axapi_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/a10_thunder_axapi/a10_thunder_axapi_connect.php
+++ b/a10_thunder_axapi/a10_thunder_axapi_connect.php
@@ -94,7 +94,7 @@ class DeviceConnection extends RestConnection
         $jres['message'] = $ret->res_body;
         $jresult['response'] = $jres;
 
-        $SMS_RETURN_BUF = json_encode($jresult, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF = object_to_json($jresult);
 
         return $ret->res_body;
       }

--- a/a10_thunder_axapi/a10_thunder_axapi_connect.php
+++ b/a10_thunder_axapi/a10_thunder_axapi_connect.php
@@ -94,7 +94,7 @@ class DeviceConnection extends RestConnection
         $jres['message'] = $ret->res_body;
         $jresult['response'] = $jres;
 
-        $SMS_RETURN_BUF = json_encode($jresult);
+        $SMS_RETURN_BUF = json_encode($jresult, JSON_FORCE_OBJECT);
 
         return $ret->res_body;
       }

--- a/aws_generic/aws_generic_apply_conf.php
+++ b/aws_generic/aws_generic_apply_conf.php
@@ -35,7 +35,7 @@ function aws_apply_conf($configuration)
     if (!empty($line))
     {
       $res = sendexpectone(__FILE__ . ':' . __LINE__, $sms_sd_ctx, $line, '//root');
-      $SMS_RETURN_BUF = json_encode($res, JSON_FORCE_OBJECT);
+      $SMS_RETURN_BUF = object_to_json($res);
     }
     $line = get_one_line($configuration);
   }

--- a/aws_generic/aws_generic_apply_conf.php
+++ b/aws_generic/aws_generic_apply_conf.php
@@ -35,7 +35,7 @@ function aws_apply_conf($configuration)
     if (!empty($line))
     {
       $res = sendexpectone(__FILE__ . ':' . __LINE__, $sms_sd_ctx, $line, '//root');
-      $SMS_RETURN_BUF = json_encode($res);
+      $SMS_RETURN_BUF = json_encode($res, JSON_FORCE_OBJECT);
     }
     $line = get_one_line($configuration);
   }

--- a/aws_generic/aws_generic_command.php
+++ b/aws_generic/aws_generic_command.php
@@ -111,7 +111,7 @@ class aws_generic_command extends generic_command
         }
 
         $this->parsed_objects = $objects;
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/aws_generic/aws_generic_command.php
+++ b/aws_generic/aws_generic_command.php
@@ -111,7 +111,7 @@ class aws_generic_command extends generic_command
         }
 
         $this->parsed_objects = $objects;
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/catalyst_ios/catalyst_command.php
+++ b/catalyst_ios/catalyst_command.php
@@ -99,7 +99,7 @@ class catalyst_command extends generic_command
       $this->parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+      $SMS_RETURN_BUF .= object_to_json($objects);
 
     }
 

--- a/catalyst_ios/catalyst_command.php
+++ b/catalyst_ios/catalyst_command.php
@@ -99,7 +99,7 @@ class catalyst_command extends generic_command
       $this->parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects);
+      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
 
     }
 

--- a/catalyst_ios/catalyst_ios_command.php
+++ b/catalyst_ios/catalyst_ios_command.php
@@ -99,7 +99,7 @@ class catalyst_ios_command extends generic_command
       $this->parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects);
+      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
 
     }
 

--- a/catalyst_ios/catalyst_ios_command.php
+++ b/catalyst_ios/catalyst_ios_command.php
@@ -99,7 +99,7 @@ class catalyst_ios_command extends generic_command
       $this->parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+      $SMS_RETURN_BUF .= object_to_json($objects);
 
     }
 

--- a/cisco_asa_generic/cisco_asa_generic_command.php
+++ b/cisco_asa_generic/cisco_asa_generic_command.php
@@ -108,7 +108,7 @@ class cisco_asa_generic_command extends generic_command
       $this->parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects);
+      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
     }
 
     unset($on_error_fct);

--- a/cisco_asa_generic/cisco_asa_generic_command.php
+++ b/cisco_asa_generic/cisco_asa_generic_command.php
@@ -108,7 +108,7 @@ class cisco_asa_generic_command extends generic_command
       $this->parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+      $SMS_RETURN_BUF .= object_to_json($objects);
     }
 
     unset($on_error_fct);

--- a/cisco_isr/cisco_isr_command.php
+++ b/cisco_isr/cisco_isr_command.php
@@ -119,7 +119,7 @@ class cisco_isr_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();
@@ -247,7 +247,7 @@ class cisco_isr_command extends generic_command
       $this->iba_parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects);
+      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
     }
 
     unset($on_error_fct);

--- a/cisco_isr/cisco_isr_command.php
+++ b/cisco_isr/cisco_isr_command.php
@@ -119,7 +119,7 @@ class cisco_isr_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();
@@ -247,7 +247,7 @@ class cisco_isr_command extends generic_command
       $this->iba_parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+      $SMS_RETURN_BUF .= object_to_json($objects);
     }
 
     unset($on_error_fct);

--- a/cisco_nexus9000/cisco_nexus9000_command.php
+++ b/cisco_nexus9000/cisco_nexus9000_command.php
@@ -109,7 +109,7 @@ class cisco_nexus9000_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/cisco_nexus9000/cisco_nexus9000_command.php
+++ b/cisco_nexus9000/cisco_nexus9000_command.php
@@ -109,7 +109,7 @@ class cisco_nexus9000_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/esa/esa_command.php
+++ b/esa/esa_command.php
@@ -112,7 +112,7 @@ class esa_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/esa/esa_command.php
+++ b/esa/esa_command.php
@@ -112,7 +112,7 @@ class esa_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/f5_bigip/f5_bigip_command.php
+++ b/f5_bigip/f5_bigip_command.php
@@ -89,7 +89,7 @@ class f5_bigip_command extends generic_command {
                 $this->parsed_objects = $objects;
 
                 debug_object_conf ( $objects );
-                $SMS_RETURN_BUF .= json_encode ($objects, JSON_FORCE_OBJECT);
+                $SMS_RETURN_BUF .= object_to_json ( $objects );
             }
 
             sd_disconnect ();
@@ -146,7 +146,7 @@ class f5_bigip_command extends generic_command {
             $this->parsed_objects = $objects;
 
             debug_object_conf ( $objects );
-            $SMS_RETURN_BUF .= json_encode ($objects, JSON_FORCE_OBJECT);
+            $SMS_RETURN_BUF .= object_to_json ( $objects );
         }
 
         return SMS_OK;

--- a/f5_bigip/f5_bigip_command.php
+++ b/f5_bigip/f5_bigip_command.php
@@ -89,7 +89,7 @@ class f5_bigip_command extends generic_command {
                 $this->parsed_objects = $objects;
 
                 debug_object_conf ( $objects );
-                $SMS_RETURN_BUF .= json_encode ( $objects );
+                $SMS_RETURN_BUF .= json_encode ($objects, JSON_FORCE_OBJECT);
             }
 
             sd_disconnect ();
@@ -146,7 +146,7 @@ class f5_bigip_command extends generic_command {
             $this->parsed_objects = $objects;
 
             debug_object_conf ( $objects );
-            $SMS_RETURN_BUF .= json_encode ( $objects );
+            $SMS_RETURN_BUF .= json_encode ($objects, JSON_FORCE_OBJECT);
         }
 
         return SMS_OK;

--- a/fortinet_generic/do_cmd_get_ha_status.php
+++ b/fortinet_generic/do_cmd_get_ha_status.php
@@ -139,7 +139,7 @@ if(count($match_ha) > 0)
 	}
 }
 
-$result =  json_encode($result_array);
+$result =  json_encode($result_array, JSON_FORCE_OBJECT);
 
 sms_send_user_ok($sms_csp, $sdid, $result);
 

--- a/fortinet_generic/do_cmd_get_ha_status.php
+++ b/fortinet_generic/do_cmd_get_ha_status.php
@@ -139,7 +139,7 @@ if(count($match_ha) > 0)
 	}
 }
 
-$result =  json_encode($result_array, JSON_FORCE_OBJECT);
+$result = object_to_json($result_array);
 
 sms_send_user_ok($sms_csp, $sdid, $result);
 

--- a/fortinet_generic/fortinet_generic_command.php
+++ b/fortinet_generic/fortinet_generic_command.php
@@ -105,7 +105,7 @@ class fortinet_generic_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/juniper_contrail/juniper_contrail_command.php
+++ b/juniper_contrail/juniper_contrail_command.php
@@ -135,7 +135,7 @@ class juniper_contrail_command extends generic_command
         }
 
         $this->parsed_objects = $objects;
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/juniper_contrail/juniper_contrail_command.php
+++ b/juniper_contrail/juniper_contrail_command.php
@@ -135,7 +135,7 @@ class juniper_contrail_command extends generic_command
         }
 
         $this->parsed_objects = $objects;
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/juniper_srx/juniper_srx_command.php
+++ b/juniper_srx/juniper_srx_command.php
@@ -98,7 +98,7 @@ class juniper_srx_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();
@@ -161,7 +161,7 @@ class juniper_srx_command extends generic_command
       $this->parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+      $SMS_RETURN_BUF .= object_to_json($objects);
     }
 
     return SMS_OK;

--- a/juniper_srx/juniper_srx_command.php
+++ b/juniper_srx/juniper_srx_command.php
@@ -98,7 +98,7 @@ class juniper_srx_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();
@@ -161,7 +161,7 @@ class juniper_srx_command extends generic_command
       $this->parsed_objects = $objects;
 
       debug_object_conf($objects);
-      $SMS_RETURN_BUF .= json_encode($objects);
+      $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
     }
 
     return SMS_OK;

--- a/linux_generic/linux_generic_command.php
+++ b/linux_generic/linux_generic_command.php
@@ -99,7 +99,7 @@ class linux_generic_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/linux_generic/linux_generic_command.php
+++ b/linux_generic/linux_generic_command.php
@@ -99,7 +99,7 @@ class linux_generic_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/netasq/netasq_command.php
+++ b/netasq/netasq_command.php
@@ -105,7 +105,7 @@ class netasq_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/netasq/netasq_command.php
+++ b/netasq/netasq_command.php
@@ -105,7 +105,7 @@ class netasq_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/netconf_generic/netconf_generic_command.php
+++ b/netconf_generic/netconf_generic_command.php
@@ -114,7 +114,7 @@ class netconf_generic_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/netconf_generic/netconf_generic_command.php
+++ b/netconf_generic/netconf_generic_command.php
@@ -114,7 +114,7 @@ class netconf_generic_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/oneaccess_lbb/oneaccess_lbb_command.php
+++ b/oneaccess_lbb/oneaccess_lbb_command.php
@@ -106,7 +106,7 @@ class oneaccess_lbb_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/oneaccess_lbb/oneaccess_lbb_command.php
+++ b/oneaccess_lbb/oneaccess_lbb_command.php
@@ -106,7 +106,7 @@ class oneaccess_lbb_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/openstack_keystone_v3/openstack_keystone_v3_command.php
+++ b/openstack_keystone_v3/openstack_keystone_v3_command.php
@@ -111,7 +111,7 @@ class openstack_keystone_v3_command extends generic_command
         }
 
         $this->parsed_objects = $objects;
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/openstack_keystone_v3/openstack_keystone_v3_command.php
+++ b/openstack_keystone_v3/openstack_keystone_v3_command.php
@@ -111,7 +111,7 @@ class openstack_keystone_v3_command extends generic_command
         }
 
         $this->parsed_objects = $objects;
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/paloalto_generic/paloalto_generic_command.php
+++ b/paloalto_generic/paloalto_generic_command.php
@@ -112,7 +112,7 @@ class paloalto_generic_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/paloalto_generic/paloalto_generic_command.php
+++ b/paloalto_generic/paloalto_generic_command.php
@@ -112,7 +112,7 @@ class paloalto_generic_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/vmware_vsphere/vmware_vsphere_command.php
+++ b/vmware_vsphere/vmware_vsphere_command.php
@@ -111,7 +111,7 @@ class vmware_vsphere_command extends generic_command
         }
 
         $this->parsed_objects = $objects;
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/vmware_vsphere/vmware_vsphere_command.php
+++ b/vmware_vsphere/vmware_vsphere_command.php
@@ -111,7 +111,7 @@ class vmware_vsphere_command extends generic_command
         }
 
         $this->parsed_objects = $objects;
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();

--- a/wsa/wsa_command.php
+++ b/wsa/wsa_command.php
@@ -109,7 +109,7 @@ class wsa_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
+        $SMS_RETURN_BUF .= object_to_json($objects);
       }
 
       sd_disconnect();

--- a/wsa/wsa_command.php
+++ b/wsa/wsa_command.php
@@ -109,7 +109,7 @@ class wsa_command extends generic_command
         $this->parsed_objects = $objects;
 
         debug_object_conf($objects);
-        $SMS_RETURN_BUF .= json_encode($objects);
+        $SMS_RETURN_BUF .= json_encode($objects, JSON_FORCE_OBJECT);
       }
 
       sd_disconnect();


### PR DESCRIPTION
- reflect PR#55 in MSA = Fix json encode for import
- perform similar fix on other non-MSA DA

/!\ this PR needs an updated `smsd/php/sms_common.php`
```
--- a/smsd/php/sms_common.php
+++ b/smsd/php/sms_common.php

+function object_to_json($object) {
+       return json_encode($object, JSON_FORCE_OBJECT);
+}
```