### PR TITLE
issue with AWS region setting in device adaptor

### DIFF
--- a/aws_generic/aws_generic_connect.php
+++ b/aws_generic/aws_generic_connect.php
@@ -27,7 +27,7 @@ class AWSSDKConnection extends GenericConnection
     $sd = &$network->SD;
     $this->key = $this->sd_login_entry;
     $this->secret = $this->sd_passwd_entry;
-    $this->region = $sd->SD_EXTERNAL_REFERENCE;
+    $this->region = $sd->SD_HOSTNAME;
     
     $cmd = "Aws\Iam\IamClient#listAccessKeys#";
     $result = $this->sendexpectone(__FILE__ . ':' . __LINE__, $cmd, "");    
@@ -86,24 +86,24 @@ class AWSSDKConnection extends GenericConnection
    			'region' => $this->region
    		));
 
-    	$awsAction = $action[1];
+    		$awsAction = $action[1];
    		if (isset($action[2])) {
    			$awsActionParams = json_decode($action[2], true);
    			$result = $client->$awsAction($awsActionParams);
-
-#			echo "AWS action params : $action[2]\n";
-#			echo "AWS awsActionParam jsondecode : $awsActionParams\n";
-#	                echo "AWS Action result: $result\n";
    		}
    		else {
    			$result = $client->$awsAction();
    		}
+                echo "AWS action params : $action[2]\n";
+                echo "AWS awsActionParam jsondecode : $awsActionParams\n";
+                echo "AWS Action result: $result\n";
+
    		//if (!is_array($result)) {
    		//	throw new SmsException("Call to SDK command failed : $result", ERR_SD_CMDFAILED);
    		//}
    		$array = $result->toArray();
     }
-    catch (Exception $e) {
+    catch (Exception | Error $e) {
     	throw new SmsException("Call to SDK command failed : $e", ERR_SD_CMDFAILED);
     }
     

--- a/aws_generic/aws_generic_connect.php
+++ b/aws_generic/aws_generic_connect.php
@@ -103,8 +103,8 @@ class AWSSDKConnection extends GenericConnection
    		//}
    		$array = $result->toArray();
     }
-    catch (Exception | Error $e) {
-    	throw new SmsException("Call to SDK command failed : $e", ERR_SD_CMDFAILED);
+    catch (Exception $e) {
+	throw new SmsException("Call to SDK command failed : $e", ERR_SD_CMDFAILED);
     }
     
     // call array to xml conversion function


### PR DESCRIPTION
fix issue related to the use of the external ref for specifying the AWS region.
the use of external reference was limiting the definition of an AWS device to only one per MSA. 
to fix this, the region will have to be set on the hostname field